### PR TITLE
fix: change from em to rem

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -654,18 +654,18 @@ $input-btn-focus-color: rgba($component-active-bg, 0.25) !default;
 $input-btn-focus-box-shadow: 0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
 
 $input-btn-font-size-pixels: 14 !default;
-$input-btn-padding-y: 1em * 10 / $input-btn-font-size-pixels !default;
-$input-btn-padding-x: 1em * 24 / $input-btn-font-size-pixels !default;
+$input-btn-padding-y: 1rem * 10 / $input-btn-font-size-pixels !default;
+$input-btn-padding-x: 1rem * 24 / $input-btn-font-size-pixels !default;
 $input-btn-font-size: from-pixels($input-btn-font-size-pixels) !default;
 $input-btn-line-height: 1.25 !default;
 
-$input-btn-padding-y-sm: 1em * 6 / $input-btn-font-size-pixels !default;
-$input-btn-padding-x-sm: 1em * 24 / $input-btn-font-size-pixels !default;
+$input-btn-padding-y-sm: 1rem * 6 / $input-btn-font-size-pixels !default;
+$input-btn-padding-x-sm: 1rem * 24 / $input-btn-font-size-pixels !default;
 $input-btn-font-size-sm: $input-btn-font-size !default;
 $input-btn-line-height-sm: $line-height-sm !default;
 
-$input-btn-padding-y-lg: 1em * 10 / $input-btn-font-size-pixels !default;
-$input-btn-padding-x-lg: 1em * 24 / $input-btn-font-size-pixels !default;
+$input-btn-padding-y-lg: 1rem * 10 / $input-btn-font-size-pixels !default;
+$input-btn-padding-x-lg: 1rem * 24 / $input-btn-font-size-pixels !default;
 $input-btn-font-size-lg: from-pixels(16) !default;
 $input-btn-line-height-lg: $line-height-lg !default;
 
@@ -917,7 +917,7 @@ $custom-select-padding-x: $input-padding-x !default;
 $custom-select-font-family: $input-font-family !default;
 $custom-select-font-size: $input-font-size !default;
 $custom-select-height: $input-height !default;
-$custom-select-indicator-padding: 1em !default; // Extra padding to account for the presence of the background-image based indicator
+$custom-select-indicator-padding: 1rem !default; // Extra padding to account for the presence of the background-image based indicator
 $custom-select-font-weight: $input-font-weight !default;
 $custom-select-line-height: $input-line-height !default;
 $custom-select-color: $input-color !default;


### PR DESCRIPTION
This may fix the buttons showing varying sizes in different browsers. 

On bootstrap website, the same button dimensions render in each browser as follows:
FF:   81.6333 x 38
Sa:   82 x 38px
Ch:  81.55 x 38

This branch, the same button dimensions render in each browser as follows:
FF: 101.18 x 43.8
Sa: 101 x 43
Ch: 101.14 x 43.28