### PR TITLE
fix: update documentation with correct class

### DIFF
--- a/site/docs/content/typography.md
+++ b/site/docs/content/typography.md
@@ -335,7 +335,7 @@ Easily realign text to components with text alignment classes.
       <td>
         {{ "`.text-justify`" | markdownify }}
       </td>
-      <td><h1 class="text-right">Text aligns to the justify.</h1></td>
+      <td><h1 class=“text-justify”>Text aligns to the justify.</h1></td>
     </tr>
   </tbody>
 </table>

--- a/site/docs/content/typography.md
+++ b/site/docs/content/typography.md
@@ -335,7 +335,7 @@ Easily realign text to components with text alignment classes.
       <td>
         {{ "`.text-justify`" | markdownify }}
       </td>
-      <td><h1 class=“text-justify”>Text aligns to the justify.</h1></td>
+      <td><h1 class="text-justify">Text aligns to the justify.</h1></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
text justify had the wrong class attached in the example.