### PR TITLE
chore(release): 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [0.4.0](https://github.com/flocasts/flo-scss/compare/v0.3.0...v0.4.0) (2020-02-25)
+## [0.5.2](https://github.com/flocasts/flo-scss/compare/v0.3.0...v0.5.2) (2020-02-25)
 
 
 ### Features
 
-* **svg:** init svg icon sprite ([#21](https://github.com/flocasts/flo-scss/issues/21)) ([3e97e78](https://github.com/flocasts/flo-scss/commit/3e97e781d7fb46476d7fe6df2f4583d5b2460982))
+* typography ([87df4b4](hhttps://github.com/flocasts/flo-scss/commit/87df4b472aad7954b8b55a940f2b8c5bc202aefa))
+
 
 ### [0.3.1](https://github.com/flocasts/flo-scss/compare/v0.3.0...v0.3.1) (2020-02-25)
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-current_version: 0.4.0
+current_version: 0.5.2
 markdown: kramdown
 highlighter: rouge
 kramdown:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flosportsinc/flo-scss",
   "description": "Based on The most popular front-end framework for developing responsive, mobile first projects on the web.",
-  "version": "0.4.0",
+  "version": "0.5.2",
   "version_short": "0.1",
   "keywords": [
     "css",


### PR DESCRIPTION
Updating version. Right now I had to manually do this in the command line with `npm run release-version 0.4.0 0.5.2`