### PR TITLE
feat(button-group): button group styling and documentation

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -1,3 +1,29 @@
+//Variables adn Mixins
+
+$btn-group-focus: 0 0 0 $btn-focus-width rgba(255, 20, 15, 0.2) !important;
+
+@mixin btn-outline-secondary-active{
+  color: $gray-100;
+  background-color: $primary;
+  border: solid $btn-border-width $primary;
+}
+
+@mixin btn-group-inactive {
+  color: $gray-500;
+  border-color: $gray-300;
+  background-color: $gray-100;
+}
+
+@mixin button-group-border-right-radius($radius) {
+    border-top-right-radius: $radius;
+    border-bottom-right-radius: $radius;
+}
+
+@mixin button-group-border-left-radius($radius) {
+  border-top-left-radius: $radius;
+  border-bottom-left-radius: $radius;
+}
+
 // stylelint-disable selector-no-qualifying-type
 
 // Make the div behave like a button
@@ -10,6 +36,11 @@
   > .btn {
     position: relative;
     flex: 1 1 auto;
+    min-width: 0;
+
+    @include media-breakpoint-down(sm){
+      @include button-size($btn-padding-y-lg, $btn-padding-x-lg, $btn-font-size-lg, $btn-line-height-lg, $btn-border-radius-lg);
+    }
 
     // Bring the hover, focused, and "active" buttons to the front to overlay
     // the borders properly
@@ -21,6 +52,39 @@
     &.active {
       z-index: 1;
     }
+  }
+
+  .btn-outline-secondary{
+    @include btn-group-inactive();
+
+    &:hover,
+    &.hover,
+    &:hover:not([disabled]){
+      @include btn-outline-secondary-active;
+    }
+    &:active,
+    &.active {
+    @include btn-outline-secondary-active;
+    pointer-events: none;
+
+      &:focus,
+      &.focus,
+      &:focus:not([disabled]){
+        color: $gray-100;
+        background-color: $primary;
+        box-shadow: $btn-group-focus;
+        outline: none;
+      }
+    }
+
+    &:focus,
+    &.focus,
+    &:focus:not([disabled]) {
+      @include btn-group-inactive();
+      box-shadow: $btn-group-focus;
+      outline: none;
+    }
+
   }
 }
 
@@ -38,19 +102,19 @@
 .btn-group {
   // Prevent double borders when buttons are next to each other
   > .btn:not(:first-child),
-  > .btn-group:not(:first-child) {
+  > .btn-group:not(:first-child){
     margin-left: -$btn-border-width;
   }
 
   // Reset rounded corners
   > .btn:not(:last-child):not(.dropdown-toggle),
   > .btn-group:not(:last-child) > .btn {
-    @include button-border-right-radius(0);
+    @include button-group-border-right-radius(0);
   }
 
   > .btn:not(:first-child),
   > .btn-group:not(:first-child) > .btn {
-    @include button-border-left-radius(0);
+    @include button-group-border-left-radius(0);
   }
 }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -87,7 +87,6 @@ fieldset:disabled a.btn {
     background-color: $gray-400;
     border-color: $gray-400;
     opacity: 1;
-    pointer-events: none;
   }
 }
 

--- a/site/docs/components/button-group.md
+++ b/site/docs/components/button-group.md
@@ -45,6 +45,8 @@ In addition, groups and toolbars should be given an explicit label, as most assi
 ***
 
 ## System Extras
+​
+Settings inherited from forking Bootstrap 4. These are not part of the design system, yet could be beneficial in the future.
 
 ### Button toolbar
 

--- a/site/docs/components/button-group.md
+++ b/site/docs/components/button-group.md
@@ -1,20 +1,32 @@
 ---
 layout: docs
 title: Button group
-description: Group a series of buttons together on a single line with the button group, and super-power them with JavaScript.
+description: Group a series of buttons together on a single line with the button group.
 group: components
 toc: true
 ---
 
-## Basic example
-
-Wrap a series of buttons with `.btn` in `.btn-group`. Add on optional JavaScript radio and checkbox style behavior with [our buttons plugin]({{ site.baseurl }}/docs/components/buttons/#button-plugin).
+## Two Buttons 
+Wrap a series of buttons with `.btn` in `.btn-group` with a `w-100` to take up 100% of the parent element. Button groups inherit a height from `.btn` on tablet and desktop devices. Button groups inherit a height from `.btn-lg` on mobile devices.  
 
 {% capture example %}
-<div class="btn-group" role="group" aria-label="Basic example">
-  <button type="button" class="btn btn-secondary">Left</button>
-  <button type="button" class="btn btn-secondary">Middle</button>
-  <button type="button" class="btn btn-secondary">Right</button>
+<div class="btn-group w-100" role="group" aria-label="Basic example two buttons">
+  <button type="button" class="btn btn-outline-secondary active">Left</button>
+  <button type="button" class="btn btn-outline-secondary">Right</button>
+</div>
+{% endcapture %}
+{% include example.html content=example %}
+
+
+## Three Buttons
+
+Wrap a series of buttons with `.btn` in `.btn-group`. 
+
+{% capture example %}
+<div class="btn-group w-100" role="group" aria-label="Basic example three buttons">
+  <button type="button" class="btn btn-outline-secondary active">Left</button>
+  <button type="button" class="btn btn-outline-secondary">Middle</button>
+  <button type="button" class="btn btn-outline-secondary">Right</button>
 </div>
 {% endcapture %}
 {% include example.html content=example %}
@@ -28,25 +40,31 @@ In addition, groups and toolbars should be given an explicit label, as most assi
 {% endcapture %}
 {% include callout.html content=callout type="warning" %}
 
-## Button toolbar
+<!-- Bootstrap 4 -->
+
+***
+
+## System Extras
+
+### Button toolbar
 
 Combine sets of button groups into button toolbars for more complex components. Use utility classes as needed to space out groups, buttons, and more.
 
 {% capture example %}
 <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
   <div class="btn-group mr-2" role="group" aria-label="First group">
-    <button type="button" class="btn btn-secondary">1</button>
-    <button type="button" class="btn btn-secondary">2</button>
-    <button type="button" class="btn btn-secondary">3</button>
-    <button type="button" class="btn btn-secondary">4</button>
+    <button type="button" class="btn btn-dark">1</button>
+    <button type="button" class="btn btn-dark">2</button>
+    <button type="button" class="btn btn-dark">3</button>
+    <button type="button" class="btn btn-dark">4</button>
   </div>
   <div class="btn-group mr-2" role="group" aria-label="Second group">
-    <button type="button" class="btn btn-secondary">5</button>
-    <button type="button" class="btn btn-secondary">6</button>
-    <button type="button" class="btn btn-secondary">7</button>
+    <button type="button" class="btn btn-dark">5</button>
+    <button type="button" class="btn btn-dark">6</button>
+    <button type="button" class="btn btn-dark">7</button>
   </div>
   <div class="btn-group" role="group" aria-label="Third group">
-    <button type="button" class="btn btn-secondary">8</button>
+    <button type="button" class="btn btn-dark">8</button>
   </div>
 </div>
 {% endcapture %}
@@ -57,10 +75,10 @@ Feel free to mix input groups with button groups in your toolbars. Similar to th
 {% capture example %}
 <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
   <div class="btn-group mr-2" role="group" aria-label="First group">
-    <button type="button" class="btn btn-secondary">1</button>
-    <button type="button" class="btn btn-secondary">2</button>
-    <button type="button" class="btn btn-secondary">3</button>
-    <button type="button" class="btn btn-secondary">4</button>
+    <button type="button" class="btn btn-dark">1</button>
+    <button type="button" class="btn btn-dark">2</button>
+    <button type="button" class="btn btn-dark">3</button>
+    <button type="button" class="btn btn-dark">4</button>
   </div>
   <div class="input-group">
     <div class="input-group-prepend">
@@ -72,10 +90,10 @@ Feel free to mix input groups with button groups in your toolbars. Similar to th
 
 <div class="btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
   <div class="btn-group" role="group" aria-label="First group">
-    <button type="button" class="btn btn-secondary">1</button>
-    <button type="button" class="btn btn-secondary">2</button>
-    <button type="button" class="btn btn-secondary">3</button>
-    <button type="button" class="btn btn-secondary">4</button>
+    <button type="button" class="btn btn-dark">1</button>
+    <button type="button" class="btn btn-dark">2</button>
+    <button type="button" class="btn btn-dark">3</button>
+    <button type="button" class="btn btn-dark">4</button>
   </div>
   <div class="input-group">
     <div class="input-group-prepend">
@@ -87,27 +105,27 @@ Feel free to mix input groups with button groups in your toolbars. Similar to th
 {% endcapture %}
 {% include example.html content=example %}
 
-## Sizing
+### Sizing
 
 Instead of applying button sizing classes to every button in a group, just add `.btn-group-*` to each `.btn-group`, including each one when nesting multiple groups.
 
 <div class="bd-example">
   <div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
-    <button type="button" class="btn btn-secondary">Left</button>
-    <button type="button" class="btn btn-secondary">Middle</button>
-    <button type="button" class="btn btn-secondary">Right</button>
+    <button type="button" class="btn btn-dark">Left</button>
+    <button type="button" class="btn btn-dark">Middle</button>
+    <button type="button" class="btn btn-dark">Right</button>
   </div>
   <br>
   <div class="btn-group" role="group" aria-label="Default button group">
-    <button type="button" class="btn btn-secondary">Left</button>
-    <button type="button" class="btn btn-secondary">Middle</button>
-    <button type="button" class="btn btn-secondary">Right</button>
+    <button type="button" class="btn btn-dark">Left</button>
+    <button type="button" class="btn btn-dark">Middle</button>
+    <button type="button" class="btn btn-dark">Right</button>
   </div>
   <br>
   <div class="btn-group btn-group-sm" role="group" aria-label="Small button group">
-    <button type="button" class="btn btn-secondary">Left</button>
-    <button type="button" class="btn btn-secondary">Middle</button>
-    <button type="button" class="btn btn-secondary">Right</button>
+    <button type="button" class="btn btn-dark">Left</button>
+    <button type="button" class="btn btn-dark">Middle</button>
+    <button type="button" class="btn btn-dark">Right</button>
   </div>
 </div>
 
@@ -117,17 +135,17 @@ Instead of applying button sizing classes to every button in a group, just add `
 <div class="btn-group btn-group-sm" role="group" aria-label="...">...</div>
 {% endhighlight %}
 
-## Nesting
+### Nesting
 
 Place a `.btn-group` within another `.btn-group` when you want dropdown menus mixed with a series of buttons.
 
 {% capture example %}
 <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
-  <button type="button" class="btn btn-secondary">1</button>
-  <button type="button" class="btn btn-secondary">2</button>
+  <button type="button" class="btn btn-dark">1</button>
+  <button type="button" class="btn btn-dark">2</button>
 
   <div class="btn-group" role="group">
-    <button id="btnGroupDrop1" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button id="btnGroupDrop1" type="button" class="btn btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       Dropdown
     </button>
     <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
@@ -139,28 +157,28 @@ Place a `.btn-group` within another `.btn-group` when you want dropdown menus mi
 {% endcapture %}
 {% include example.html content=example %}
 
-## Vertical variation
+### Vertical variation
 
 Make a set of buttons appear vertically stacked rather than horizontally. **Split button dropdowns are not supported here.**
 
 <div class="bd-example">
   <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
-    <button type="button" class="btn btn-secondary">Button</button>
-    <button type="button" class="btn btn-secondary">Button</button>
-    <button type="button" class="btn btn-secondary">Button</button>
-    <button type="button" class="btn btn-secondary">Button</button>
-    <button type="button" class="btn btn-secondary">Button</button>
-    <button type="button" class="btn btn-secondary">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
   </div>
 </div>
 
 
 <div class="bd-example">
   <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
-    <button type="button" class="btn btn-secondary">Button</button>
-    <button type="button" class="btn btn-secondary">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop1" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button id="btnGroupVerticalDrop1" type="button" class="btn btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Dropdown
       </button>
       <div class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop1">
@@ -168,10 +186,10 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
         <a class="dropdown-item" href="#">Dropdown link</a>
       </div>
     </div>
-    <button type="button" class="btn btn-secondary">Button</button>
-    <button type="button" class="btn btn-secondary">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
+    <button type="button" class="btn btn-dark">Button</button>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop2" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button id="btnGroupVerticalDrop2" type="button" class="btn btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Dropdown
       </button>
       <div class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop2">
@@ -180,7 +198,7 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
       </div>
     </div>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop3" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button id="btnGroupVerticalDrop3" type="button" class="btn btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Dropdown
       </button>
       <div class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop3">
@@ -189,7 +207,7 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
       </div>
     </div>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop4" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button id="btnGroupVerticalDrop4" type="button" class="btn btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Dropdown
       </button>
       <div class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop4">


### PR DESCRIPTION
FLO-11212

Button Groups - Since they work as a filter (toggle) Added  a pointer-events: none; (line 68) to the :active. Though was it would prevent the user from clicking on it when active and refreshing the active content. Let me know if this needs to change.