### PR TITLE
docs: removing reference to JS in docs

### DIFF
--- a/site/_data/nav.yml
+++ b/site/_data/nav.yml
@@ -34,7 +34,6 @@
     - title: Buttons
     - title: Button group
     - title: Card
-    - title: Carousel
     - title: Chips
     - title: Collapse
     - title: Dropdowns
@@ -48,14 +47,10 @@
     - title: Navs
     - title: Navbar
     - title: Pagination
-    - title: Popovers
     - title: Progress
-    - title: Scrollspy
     - title: Shapes
     - title: Spinners
     - title: Tabs
-    - title: Toasts
-    - title: Tooltips
     - title: Video Tile
 
 - title: Utilities

--- a/site/_includes/docs-navbar.html
+++ b/site/_includes/docs-navbar.html
@@ -34,25 +34,6 @@
       <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="versions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         v{{ site.current_version }}
       </a>
-      <div class="dropdown-menu dropdown-menu-md-right" aria-labelledby="versions">
-        <a class="dropdown-item active" href="{{ site.baseurl }}/docs/">Latest (4.4.x)</a>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/4.3/">v4.3.1</a>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/4.2/">v4.2.1</a>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/4.0/">v4.0.0</a>
-        <div class="dropdown-divider"></div>
-        <a class="dropdown-item" href="https://v4-alpha.getbootstrap.com/">v4 Alpha 6</a>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/3.3/">v3.3.7</a>
-        <a class="dropdown-item" href="https://getbootstrap.com/2.3.2/">v2.3.2</a>
-        <div class="dropdown-divider"></div>
-        <a class="dropdown-item" href="{{ site.baseurl }}/docs/versions/">All versions</a>
-      </div>
-    </li>
-
-    <li class="nav-item">
-      <a class="nav-link p-2" href="{{ site.repo }}" target="_blank" rel="noopener" aria-label="GitHub">
-        {%- include icons/github.svg class="navbar-nav-svg" -%}
-      </a>
     </li>
   </ul>
 

--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -1,12 +1,6 @@
 <footer class="bd-footer text-muted">
   <div class="container-fluid p-3 p-md-5">
-    <ul class="bd-footer-links">
-      <li><a href="{{ site.repo }}">GitHub</a></li>
-      <li><a href="https://twitter.com/{{ site.twitter }}">Twitter</a></li>
-      <li><a href="{{ site.baseurl }}/docs/examples/">Examples</a></li>
-      <li><a href="{{ site.baseurl }}/docs/about/overview/">About</a></li>
-    </ul>
-    <p>Designed and built with all the love in the world by the <a href="{{ site.baseurl }}/docs/about/team/">Bootstrap team</a> with the help of <a href="{{ site.repo }}/graphs/contributors">our contributors</a>.</p>
+    <p>Designed on top of the Bootstrap livbrary which was built with all the love in the world by the <a href="{{ site.baseurl }}/docs/about/team/">Bootstrap team</a> with the help of <a href="{{ site.repo }}/graphs/contributors">their contributors</a>.</p>
     <p>Currently v{{ site.current_version }}. Code licensed <a href="{{ site.repo }}/blob/master/LICENSE" target="_blank" rel="license noopener">MIT</a>, docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="license noopener">CC BY 3.0</a>.</p>
   </div>
 </footer>

--- a/site/docs/components/badge.md
+++ b/site/docs/components/badge.md
@@ -5,6 +5,7 @@ description: Documentation and examples for badges, our small count and labeling
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## Example
 

--- a/site/docs/components/breadcrumb.md
+++ b/site/docs/components/breadcrumb.md
@@ -5,6 +5,8 @@ description: Indicate the current page's location within a navigational hierarch
 group: components
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## Example
 
 {% capture example %}

--- a/site/docs/components/card.md
+++ b/site/docs/components/card.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## About
 
 A **card** is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options. If you're familiar with Bootstrap 3, cards replace our old panels, wells, and thumbnails. Similar functionality to those components is available as modifier classes for cards.

--- a/site/docs/components/carousel.md
+++ b/site/docs/components/carousel.md
@@ -5,6 +5,7 @@ description: A slideshow component for cycling through elements—images or slid
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## How it works
 

--- a/site/docs/components/carousel.md
+++ b/site/docs/components/carousel.md
@@ -5,7 +5,8 @@ description: A slideshow component for cycling through elements—images or slid
 group: components
 toc: true
 ---
-# NOT Updated for FLO-SCSS yet
+
+# Javascript is not included in FLO-SCSS
 
 ## How it works
 

--- a/site/docs/components/collapse.md
+++ b/site/docs/components/collapse.md
@@ -5,6 +5,7 @@ description: Toggle the visibility of content across your project with a few cla
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## How it works
 

--- a/site/docs/components/dropdowns.md
+++ b/site/docs/components/dropdowns.md
@@ -5,6 +5,7 @@ description: Toggle contextual overlays for displaying lists of links and more w
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## Overview
 

--- a/site/docs/components/forms.md
+++ b/site/docs/components/forms.md
@@ -5,6 +5,7 @@ description: Examples and usage guidelines for form control styles, layout optio
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## Overview
 

--- a/site/docs/components/icons.md
+++ b/site/docs/components/icons.md
@@ -5,6 +5,7 @@ description: Use SVG Icons in HTML
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## Icons
 

--- a/site/docs/components/input-group.md
+++ b/site/docs/components/input-group.md
@@ -5,6 +5,7 @@ description: Easily extend form controls by adding text, buttons, or button grou
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## Basic example
 

--- a/site/docs/components/jumbotron.md
+++ b/site/docs/components/jumbotron.md
@@ -4,6 +4,7 @@ title: Jumbotron
 description: Lightweight, flexible component for showcasing hero unit style content.
 group: components
 ---
+# NOT Updated for FLO-SCSS yet
 
 A lightweight, flexible component that can optionally extend the entire viewport to showcase key marketing messages on your site.
 

--- a/site/docs/components/list-group.md
+++ b/site/docs/components/list-group.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## Basic example
 
 The most basic list group is an unordered list with list items and the proper classes. Build upon it with the options that follow, or with your own CSS as needed.

--- a/site/docs/components/media-object.md
+++ b/site/docs/components/media-object.md
@@ -5,6 +5,7 @@ description: Documentation and examples for Bootstrap's media object to construc
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## Example
 

--- a/site/docs/components/modal.md
+++ b/site/docs/components/modal.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## How it works
 
 Before getting started with Bootstrap's modal component, be sure to read the following as our menu options have recently changed.

--- a/site/docs/components/navbar.md
+++ b/site/docs/components/navbar.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## How it works
 
 Here's what you need to know before getting started with the navbar:

--- a/site/docs/components/navs.md
+++ b/site/docs/components/navs.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## Base nav
 
 Navigation available in Bootstrap share general markup and styles, from the base `.nav` class to the active and disabled states. Swap modifier classes to switch between each style.

--- a/site/docs/components/pagination.md
+++ b/site/docs/components/pagination.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## Overview
 
 We use a large block of connected links for our pagination, making links hard to miss and easily scalable—all while providing large hit areas. Pagination is built with list HTML elements so screen readers can announce the number of available links. Use a wrapping `<nav>` element to identify it as a navigation section to screen readers and other assistive technologies.

--- a/site/docs/components/popovers.md
+++ b/site/docs/components/popovers.md
@@ -6,7 +6,7 @@ group: components
 toc: true
 ---
 
-# NOT Updated for FLO-SCSS yet
+# Javascript is not included in FLO-SCSS
 
 ## Overview
 

--- a/site/docs/components/popovers.md
+++ b/site/docs/components/popovers.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## Overview
 
 Things to know when using the popover plugin:

--- a/site/docs/components/progress.md
+++ b/site/docs/components/progress.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## How it works
 
 Progress components are built with two HTML elements, some CSS to set the width, and a few attributes. We don't use [the HTML5 `<progress>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress), ensuring you can stack progress bars, animate them, and place text labels over them.

--- a/site/docs/components/scrollspy.md
+++ b/site/docs/components/scrollspy.md
@@ -5,7 +5,8 @@ description: Automatically update Bootstrap navigation or list group components 
 group: components
 toc: true
 ---
-# NOT Updated for FLO-SCSS yet
+
+# Javascript is not included in FLO-SCSS
 
 ## How it works
 

--- a/site/docs/components/scrollspy.md
+++ b/site/docs/components/scrollspy.md
@@ -5,6 +5,7 @@ description: Automatically update Bootstrap navigation or list group components 
 group: components
 toc: true
 ---
+# NOT Updated for FLO-SCSS yet
 
 ## How it works
 

--- a/site/docs/components/shapes.md
+++ b/site/docs/components/shapes.md
@@ -9,6 +9,8 @@ redirect_from:
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 More inspiration [here](https://css-tricks.com/the-shapes-of-css/)
 
 ## Examples

--- a/site/docs/components/spinners.md
+++ b/site/docs/components/spinners.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## About
 
 Bootstrap "spinners" can be used to show the loading state in your projects. They're built only with HTML and CSS, meaning you don't need any JavaScript to create them. You will, however, need some custom JavaScript to toggle their visibility. Their appearance, alignment, and sizing can be easily customized with our amazing utility classes.

--- a/site/docs/components/toasts.md
+++ b/site/docs/components/toasts.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 Toasts are lightweight notifications designed to mimic the push notifications that have been popularized by mobile and desktop operating systems. They're built with flexbox, so they're easy to align and position.
 
 ## Overview

--- a/site/docs/components/toasts.md
+++ b/site/docs/components/toasts.md
@@ -6,7 +6,7 @@ group: components
 toc: true
 ---
 
-# NOT Updated for FLO-SCSS yet
+# Javascript is not included in FLO-SCSS
 
 Toasts are lightweight notifications designed to mimic the push notifications that have been popularized by mobile and desktop operating systems. They're built with flexbox, so they're easy to align and position.
 

--- a/site/docs/components/tooltips.md
+++ b/site/docs/components/tooltips.md
@@ -6,6 +6,8 @@ group: components
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## Overview
 
 Things to know when using the tooltip plugin:

--- a/site/docs/components/tooltips.md
+++ b/site/docs/components/tooltips.md
@@ -6,7 +6,7 @@ group: components
 toc: true
 ---
 
-# NOT Updated for FLO-SCSS yet
+# Javascript is not included in FLO-SCSS
 
 ## Overview
 

--- a/site/docs/content/tables.md
+++ b/site/docs/content/tables.md
@@ -6,6 +6,8 @@ group: content
 toc: true
 ---
 
+# NOT Updated for FLO-SCSS yet
+
 ## Examples
 
 Due to the widespread use of tables across third-party widgets like calendars and date pickers, we've designed our tables to be **opt-in**. Just add the base class `.table` to any `<table>`, then extend with custom styles or our various included modifier classes.

--- a/site/docs/utilities/colors.md
+++ b/site/docs/utilities/colors.md
@@ -6,6 +6,8 @@ group: utilities
 toc: true
 ---
 
+# NOT Completely Updated for FLO-SCSS yet
+
 ## Color
 
 {% capture example %}

--- a/site/index.html
+++ b/site/index.html
@@ -12,14 +12,12 @@ layout: home
       <div class="col-md-6 order-md-1 text-center text-md-left pr-md-5">
         <h1 class="mb-3 text-primary">Flo-SCSS</h1>
         <p class="lead">
-          Build responsive, mobile-first projects on the web with the world’s
-          most popular front-end component library.
+          FloSport's style library built on top of Bootstrap's foundations. This contains only styles and no JS.
         </p>
         <p class="lead mb-4">
-          Bootstrap is an open source toolkit for developing with HTML, CSS, and
+          More on Bootstrap: it is an open source toolkit for developing with HTML, CSS, and
           JS. Quickly prototype your ideas or build your entire app with our
-          Sass variables and mixins, responsive grid system, extensive prebuilt
-          components, and powerful plugins built on jQuery.
+          Sass variables and mixins, and responsive grid system.
         </p>
         <div class="row mx-n2">
           <div class="col-md px-2">
@@ -32,7 +30,7 @@ layout: home
           <div class="col-md px-2">
             <a
               href="https://github.com/flocasts/flo-scss/archive/v{{site.current_version}}.zip"
-              class="btn btn-lg btn-secondary w-100 mb-3"
+              class="btn btn-lg btn-secondary w-100 mb-3 disabled"
               >Download</a
             >
           </div>
@@ -44,117 +42,3 @@ layout: home
     </div>
   </div>
 </main>
-
-<div class="masthead-followup row m-0 border border-white">
-  <div class="col-md-4 p-3 p-md-5 bg-light border border-white">
-    <!-- Icon by Bytesize https://github.com/danklammer/bytesize-icons -->
-    {% include icons/import.svg width="32" height="32" class="text-primary mb-2"
-    %}
-    <h3>Quick start</h3>
-
-    <p>Several quick start options are available:</p>
-
-    <ul>
-      <li>
-        Download the latest release.
-        https://github.com/flocasts/flo-scss/archive/vflo-scss.zip
-        <strong>
-          OR
-        </strong>
-      </li>
-      <li>
-        Clone the repo:
-        <code>
-          git clone git@github.com:flocasts/flo-scss && cd flo-scss && bundle
-          install && npm i && npm run release && npm start
-        </code>
-        <strong>
-          OR
-        </strong>
-      </li>
-      <li>
-        Install with [npm](https://www.npmjs.com/):
-        <code>
-          npm install flocasts/flo-scss
-        </code>
-      </li>
-    </ul>
-
-    <hr class="half-rule" />
-    <a
-      class="btn btn-outline-primary"
-      href="{{ site.baseurl }}/docs/getting-started/download/"
-      >Read installation docs</a
-    >
-  </div>
-
-  <div class="col-md-4 p-3 p-md-5 bg-light border border-white">
-    <!-- Icon by Bytesize https://github.com/danklammer/bytesize-icons -->
-    {% include icons/download.svg width="32" height="32" class="text-primary
-    mb-2" %}
-    <h3>BootstrapCDN</h3>
-    <p>
-      When you only need to include Bootstrap’s compiled CSS or JS, you can use
-      <a href="https://www.bootstrapcdn.com/">BootstrapCDN</a>.
-    </p>
-
-    <h5>CSS only</h5>
-    {% highlight html %}
-    <link
-      rel="stylesheet"
-      href="{{ site.cdn.css }}"
-      integrity="{{ site.cdn.css_hash }}"
-      crossorigin="anonymous"
-    />
-    {% endhighlight %}
-
-    <h5>JS, Popper.js, and jQuery</h5>
-    {% highlight html %}
-    <script
-      src="{{ site.cdn.jquery }}"
-      integrity="{{ site.cdn.jquery_hash }}"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="{{ site.cdn.popper }}"
-      integrity="{{ site.cdn.popper_hash }}"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="{{ site.cdn.js }}"
-      integrity="{{ site.cdn.js_hash }}"
-      crossorigin="anonymous"
-    ></script>
-    {% endhighlight %}
-    <hr class="half-rule" />
-    <a
-      class="btn btn-outline-primary"
-      href="{{ site.baseurl }}/docs/layout/overview/"
-      >Explore the docs</a
-    >
-  </div>
-
-  <div class="col-md-4 p-3 p-md-5 bg-light border border-white">
-    <!-- Icon by Bytesize https://github.com/danklammer/bytesize-icons -->
-    {% include icons/lightning.svg width="32" height="32" class="text-primary
-    mb-2" %}
-    <h3>Official Themes</h3>
-    <p>
-      Take Bootstrap 4 to the next level with official premium themes—toolkits
-      built on Bootstrap with new components and plugins, docs, and build tools.
-    </p>
-    <img
-      class="img-fluid mt-3 mx-auto"
-      srcset="{{ site.baseurl }}/docs/assets/img/bootstrap-themes.png,
-                                                {{ site.baseurl }}/docs/assets/img/bootstrap-themes@2x.png 2x"
-      src="{{ site.baseurl }}/docs/assets/img/bootstrap-themes.png"
-      alt="Bootstrap Themes"
-      width="500"
-      height="200"
-    />
-    <hr class="half-rule" />
-    <a href="{{ site.themes }}/" class="btn btn-outline-primary"
-      >Browse themes</a
-    >
-  </div>
-</div>

--- a/site/index.html
+++ b/site/index.html
@@ -15,9 +15,7 @@ layout: home
           FloSport's style library built on top of Bootstrap's foundations. This contains only styles and no JS.
         </p>
         <p class="lead mb-4">
-          More on Bootstrap: it is an open source toolkit for developing with HTML, CSS, and
-          JS. Quickly prototype your ideas or build your entire app with our
-          Sass variables and mixins, and responsive grid system.
+          More on Bootstrap: It is an open source toolkit for web development. Quickly prototype your ideas or build your entire app with our Sass variables and mixins, and responsive grid system.
         </p>
         <div class="row mx-n2">
           <div class="col-md px-2">


### PR DESCRIPTION
https://flo-scss-remove-bootstr-fg63vw.herokuapp.com

and

https://flo-scss-remove-bootstr-fg63vw.herokuapp.com/docs/components/alerts/

In the side navigation, I removed links to components that require JS
On the index page, I removed the bottom section and updated the intro section.
Also, on each component's doc page, I put a note that it hadn't been updated for FLO-SCSS yet.