### PR TITLE
fix: tabs classes

### DIFF
--- a/scss/_tabs.scss
+++ b/scss/_tabs.scss
@@ -7,7 +7,7 @@
   border-top: $nav-tabs-border-color solid $nav-tabs-border-width;
 }
 
-label.tab-label {
+.tab-label {
   align-items: center;
   border-bottom: $gray-300 solid 1px;
   border-top: $gray-300 solid 1px;
@@ -38,7 +38,7 @@ label.tab-label {
     padding-right: 0;
   }
   
-  &.flex-tab{
+  &.flex-tab {
     flex-grow: 1;
     flex-basis: from-pixels(125);
     padding-left:  0;
@@ -62,6 +62,11 @@ input.tab-input {
 }
 
 input.tab-input:checked + label.tab-label {
+  border-bottom: $tab-border-width solid $primary;
+  color: $primary;
+}
+
+.tab-active {
   border-bottom: $tab-border-width solid $primary;
   color: $primary;
 }


### PR DESCRIPTION
The tab classes/styles were only being applied to if we build tabs out with the <label> <input> pattern. Our current tabs in our webapp are not build out like this and we need to adjust the class names so we are able to take advantage of the style work done on tabs in this repo