### PR TITLE
fix: add text color classes back in

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -63,11 +63,13 @@
 .text-white-50 { color: rgba($white, .5) !important; }
 
 @each $level, $value in $grays {
+  .text-#{$level},
   .color-#{$level} {
     color: $value;
   }
 }
 
+.text-ignite,
 .color-ignite {
   color: $primary;
 }


### PR DESCRIPTION
Putting .text-100 through 900 back in to keep the Bootstrap standard.

FLO-11370