### PR TITLE
docs: update logo documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,16 +48,16 @@ download:
 
 cdn:
   # See https://www.srihash.org for info on how to generate the hashes
-  css: 'sha384-SP5GAoAp/wsst7iEs7g9Dji7gk5qHHluNjN/pZgpHFeLrmOBXL2lqq+akEzeCsGG'
+  css: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
   css_hash: sha384-hnvsmW4CEqIE9xpwdmvw+oyi2zalIdkqZJKT8ovyObj2fiPNSLt7xdsda4JGUfSf
-  js: 'sha384-SP5GAoAp/wsst7iEs7g9Dji7gk5qHHluNjN/pZgpHFeLrmOBXL2lqq+akEzeCsGG'
+  js: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
   js_hash: sha384-1RkA5wjfeG5u+6ycZ90q+PMlafLBaMCHvGk6PlVrQmIuTvpdA9qupxwbnPf9QbHH
   js_bundle: >-
     https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js
   js_bundle_hash: sha384-gEp0IQktG6BLXHMpPT1pxMSC8EKUA159uPI9c/AmIhedq/EvAEfBroQ5tsSOS1/A
-  jquery: 'sha384-SP5GAoAp/wsst7iEs7g9Dji7gk5qHHluNjN/pZgpHFeLrmOBXL2lqq+akEzeCsGG'
+  jquery: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
   jquery_hash: sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n
-  popper: 'sha384-SP5GAoAp/wsst7iEs7g9Dji7gk5qHHluNjN/pZgpHFeLrmOBXL2lqq+akEzeCsGG'
+  popper: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
   popper_hash: sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN
 
 toc:

--- a/_config.yml
+++ b/_config.yml
@@ -31,9 +31,9 @@ social_image_path: /docs/assets/brand/bootstrap-social.png
 social_logo_path: /docs/assets/brand/bootstrap-social-logo.png
 
 # Custom Variables
-current_version:      0.7.0
-current_ruby_version: 0.7.0
-docs_version:         0.7.0
+current_version:      0.7.1
+current_ruby_version: 0.7.1
+docs_version:         0.7.1
 github_org:           "https://github.com/flocasts"
 repo:                 "https://github.com/flocasts/flo-scss"
 slack:                "https://www.flosports.tv"
@@ -44,20 +44,20 @@ themes:               "https://www.flosports.tv"
 icons:                "https://flo-scss.flo.center"
 
 download:
-  source: "https://github.com/flocasts/flo-scss/archive/v0.7.0.zip"
+  source: "https://github.com/flocasts/flo-scss/archive/v0.7.1.zip"
 
 cdn:
   # See https://www.srihash.org for info on how to generate the hashes
-  css: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
+  css: 'sha384-bTuOyWFzvtzatBsqmXxShF1CAHyTzY4LiDCiZ5xdOi/Uq4W2ss8wllsHVHbNOd5P'
   css_hash: sha384-hnvsmW4CEqIE9xpwdmvw+oyi2zalIdkqZJKT8ovyObj2fiPNSLt7xdsda4JGUfSf
-  js: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
+  js: 'sha384-bTuOyWFzvtzatBsqmXxShF1CAHyTzY4LiDCiZ5xdOi/Uq4W2ss8wllsHVHbNOd5P'
   js_hash: sha384-1RkA5wjfeG5u+6ycZ90q+PMlafLBaMCHvGk6PlVrQmIuTvpdA9qupxwbnPf9QbHH
   js_bundle: >-
     https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js
   js_bundle_hash: sha384-gEp0IQktG6BLXHMpPT1pxMSC8EKUA159uPI9c/AmIhedq/EvAEfBroQ5tsSOS1/A
-  jquery: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
+  jquery: 'sha384-bTuOyWFzvtzatBsqmXxShF1CAHyTzY4LiDCiZ5xdOi/Uq4W2ss8wllsHVHbNOd5P'
   jquery_hash: sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n
-  popper: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
+  popper: 'sha384-bTuOyWFzvtzatBsqmXxShF1CAHyTzY4LiDCiZ5xdOi/Uq4W2ss8wllsHVHbNOd5P'
   popper_hash: sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN
 
 toc:

--- a/_config.yml
+++ b/_config.yml
@@ -48,16 +48,16 @@ download:
 
 cdn:
   # See https://www.srihash.org for info on how to generate the hashes
-  css: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
+  css: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
   css_hash: sha384-hnvsmW4CEqIE9xpwdmvw+oyi2zalIdkqZJKT8ovyObj2fiPNSLt7xdsda4JGUfSf
-  js: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
+  js: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
   js_hash: sha384-1RkA5wjfeG5u+6ycZ90q+PMlafLBaMCHvGk6PlVrQmIuTvpdA9qupxwbnPf9QbHH
   js_bundle: >-
     https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js
   js_bundle_hash: sha384-gEp0IQktG6BLXHMpPT1pxMSC8EKUA159uPI9c/AmIhedq/EvAEfBroQ5tsSOS1/A
-  jquery: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
+  jquery: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
   jquery_hash: sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n
-  popper: 'sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN'
+  popper: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
   popper_hash: sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN
 
 toc:

--- a/_config.yml
+++ b/_config.yml
@@ -48,16 +48,16 @@ download:
 
 cdn:
   # See https://www.srihash.org for info on how to generate the hashes
-  css: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
+  css: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
   css_hash: sha384-hnvsmW4CEqIE9xpwdmvw+oyi2zalIdkqZJKT8ovyObj2fiPNSLt7xdsda4JGUfSf
-  js: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
+  js: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
   js_hash: sha384-1RkA5wjfeG5u+6ycZ90q+PMlafLBaMCHvGk6PlVrQmIuTvpdA9qupxwbnPf9QbHH
   js_bundle: >-
     https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js
   js_bundle_hash: sha384-gEp0IQktG6BLXHMpPT1pxMSC8EKUA159uPI9c/AmIhedq/EvAEfBroQ5tsSOS1/A
-  jquery: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
+  jquery: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
   jquery_hash: sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n
-  popper: 'sha384-KVECXYZTt1whwERGDiUFMzP40sDUFjfzxqX02VjqEeyqVyg4YXNoWg0z7F0q6qJX'
+  popper: 'sha384-MMLzfhqcj7iAztos0doM4v4OXRfBzu1mFfFV+hNw/dvth+emrA3riw9Y+XCaMyFd'
   popper_hash: sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN
 
 toc:

--- a/site/docs/assets/scss/_brand-logos.scss
+++ b/site/docs/assets/scss/_brand-logos.scss
@@ -1,5 +1,5 @@
 // color Hawk in FloSports logo
-.cbflo-svg-logo-graphic{
+.alternate-logo .cbflo-svg-logo-graphic{
   color: #ff140f;
 }
 

--- a/site/docs/assets/scss/_brand-logos.scss
+++ b/site/docs/assets/scss/_brand-logos.scss
@@ -1,7 +1,8 @@
 // color Hawk in FloSports logo
-.alternate-logo .cbflo-svg-logo-graphic{
+.cbflo-svg-logo-graphic{
   color: #ff140f;
 }
+
 
 //Co brand Colors - MileSplit
 .logo-text-mile{

--- a/site/docs/components/icons.md
+++ b/site/docs/components/icons.md
@@ -6,13 +6,13 @@ group: components
 toc: true
 ---
 
-We use svgs in the design system and not a font library to display icons. Look here for details on [Brand Logos]({{ site.baseurl }}/docs/components/logos) or [Badges]({{ site.baseurl }}/docs/components/badge).
+This page contains a list of all SVG icons available and utility classes to support them. Not included are  [Brand Logos]({{ site.baseurl }}/docs/components/logos) or [Badges]({{ site.baseurl }}/docs/components/badge).
 
-## SVGs
+## SVG
 
-Each icon in the Flo-SCSS system is a formatted svg with a `viewBox="0 0 500 500"`, a path fill="currentColor" and a descriptive class name.
+Each icon in the Flo-SCSS system is a formatted SVG with a `viewBox="0 0 500 500"`, a path fill="currentColor" and a descriptive class name.
 
-The SVG is created on a 500px x 500px art board. SVG's created in a design program such as Adobe Illustrator or Sketch. Clean up an svg with this online tool https://jakearchibald.github.io/svgomg/. Make sure no extra `g` `tags`, `masks`, or `nested paths` are present.
+The SVG is created on a 500px x 500px art board. SVG were created in a design program such as Adobe Illustrator or Sketch and cleaned up with an [online tool](https://jakearchibald.github.io/svgomg/). When using SVG, make sure there are no extra `g` `tags`, `masks`, or `nested paths` present as these uncessarily increase file size.
 
 Format Guidelines
 * `fill=currentColor` is set
@@ -26,22 +26,14 @@ Format Guidelines
 <path fill="currentColor" d="M346.382,250.246A96.882,96.882,0,1,0,249.5,347.128,96.992,96.992,0,0,0,346.382,250.246Zm93.428,35.383,42.96,24.8a12.121,12.121,0,0,1,5.5,14.1,249.617,249.617,0,0,1-55.13,95.348,12.113,12.113,0,0,1-14.952,2.273l-42.927-24.794a193.113,193.113,0,0,1-61.249,35.413v49.579a12.1,12.1,0,0,1-9.453,11.812,251.979,251.979,0,0,1-110.1.008,12.123,12.123,0,0,1-9.479-11.818V432.764a193.083,193.083,0,0,1-61.249-35.413L80.808,422.145a12.113,12.113,0,0,1-14.952-2.273,249.63,249.63,0,0,1-55.13-95.348,12.122,12.122,0,0,1,5.5-14.1l42.961-24.8a195.04,195.04,0,0,1,0-70.765l-42.96-24.8a12.121,12.121,0,0,1-5.5-14.1A249.621,249.621,0,0,1,65.857,80.62a12.113,12.113,0,0,1,14.952-2.272l42.927,24.793a193.131,193.131,0,0,1,61.249-35.413V18.149a12.108,12.108,0,0,1,9.453-11.813,252,252,0,0,1,110.1-.007,12.121,12.121,0,0,1,9.479,11.817V67.727a193.1,193.1,0,0,1,61.249,35.413l42.927-24.793a12.113,12.113,0,0,1,14.952,2.272,249.634,249.634,0,0,1,55.13,95.349,12.122,12.122,0,0,1-5.5,14.1l-42.961,24.8A195.045,195.045,0,0,1,439.81,285.629Z"/>
 </svg>
 ```
- 
-#### Flo-SCSS Sprite Sheet
-
-FLO-SCSS svg icons are displayed in a grid list generated using `svg-sprite`, is a module that takes a bunch of SVG files, optimizes them and puts them all into one svg sprite which is located here,` _includes/icon-sprite.svg`, in this app. with their names referenced in `site/_data/icons.yml.` The "All icons" section of icons.md loops through these names to presents the full svg list.
-
-To add or remove an svg, update the name in the `icons.yml` and run `npm run process-svg`
-
-TODO: explain the difference between fill="currentColor" and the use of classes in the svg.
 
 ## Manipulating SVG's
+<p class="text-ignite"><strong>Note:</strong> These examples below reference Flo-SCSS's SVG sprite sheet and may not reflect how your application references SVG. The names of the SVG icons should remain the same.</p>
 
-### Sizing
-Icons inherit width and height from the parent container, so the parent container can set its dimensions.  
+
 
 #### Modify Class
-Apply `.icon`, `.icon-sm`, and `.icon-lg` to size icons
+Apply `.icon`, `.icon-sm`, and `.icon-lg` to size icons directly.
 
 {% capture example %}
 <div class="row row-cols-4 align-items-center">
@@ -58,9 +50,25 @@ Apply `.icon`, `.icon-sm`, and `.icon-lg` to size icons
 {% endcapture %}
 {% include example.html content=example %}
 
+If SVG are added to the site dynamically, icons can inherit width and height from their parent container.
+
+{% capture example %}
+<div class="row row-cols-4 align-items-center">
+  <svg>
+    <use xlink:href="#close_circle" />
+  </svg>
+  <svg>
+    <use xlink:href="#close_circle" />
+  </svg>
+  <svg>
+    <use xlink:href="#close_circle" />
+  </svg>
+</div>
+{% endcapture %}
+
 ### Color
 
-Setting `fill=currentColor` in the SVG allows the SVG's colors to be controlled by CSS and added classes. Below you can see the SVG's color changing by adding `.color-class` to the svg or parent tag.
+Setting `fill=currentColor` in the SVG allows the SVG colors to be controlled by CSS. Below you can see the SVG color changing by adding `.color-class` to the SVG or parent tag.
 
 {% capture example %}
 <div class="row row-cols-4 color-ignite">
@@ -77,7 +85,7 @@ Setting `fill=currentColor` in the SVG allows the SVG's colors to be controlled 
 {% endcapture %}
 {% include example.html content=example %}
 
-### Brand colors 
+### Non-FLO Brand Colors 
 The following brand-specific color classes are provided:
 
 <div class="row">
@@ -139,20 +147,20 @@ Transform icons with [transform utilities](/docs/utilities/transform)
 
 {% capture example %}
 <div class="row row-cols-4">
-  <svg class="icon-sm rotate-180">
+  <svg class="icon-md rotate-180">
     <use xlink:href="#bell_regular" />
   </svg>
-    <svg class="icon-sm rotate-45">
+    <svg class="icon-md rotate-45">
     <use xlink:href="#bell_regular" />
   </svg>
-    <svg class="icon-sm rotate-135">
+    <svg class="icon-md rotate-135">
     <use xlink:href="#bell_regular" />
   </svg>
 </div>
 {% endcapture %}
 {% include example.html content=example %}
 
-## Icons
+## Icon List
 A complete list of all the SVG icons in the system.
 
 <div class="row">
@@ -166,3 +174,10 @@ A complete list of all the SVG icons in the system.
 {% endfor %}
 </div>
 
+
+
+#### Adding an SVG to the Flo-SCSS Sprite Sheet
+
+FLO-SCSS svg icons are displayed in a grid list generated using `svg-sprite`, is a module that takes a bunch of SVG files, optimizes them and puts them all into one svg sprite which is located here,` _includes/icon-sprite.svg`, in this app. with their names referenced in `site/_data/icons.yml.` The "All icons" section of icons.md loops through these names to presents the full svg list.
+
+To add or remove an svg, update the name in the `icons.yml` and run `npm run process-svg`

--- a/site/docs/components/icons.md
+++ b/site/docs/components/icons.md
@@ -12,9 +12,9 @@ This page contains a list of all SVG icons available and utility classes to supp
 
 Each icon in the Flo-SCSS system is a formatted SVG with a `viewBox="0 0 500 500"`, a path fill="currentColor" and a descriptive class name.
 
-The SVG is created on a 500px x 500px art board. SVG were created in a design program such as Adobe Illustrator or Sketch and cleaned up with an [online tool](https://jakearchibald.github.io/svgomg/). When using SVG, make sure there are no extra `g` `tags`, `masks`, or `nested paths` present as these uncessarily increase file size.
+The SVG is created on a 500px x 500px art board in a design program such as Adobe Illustrator or Sketch and cleaned up with a [svgomg](https://jakearchibald.github.io/svgomg/). When using SVG, make sure there are no extra `g` `tags`, `masks`, or `nested paths` present as these unnecessarily increase file size.
 
-Format Guidelines
+SVG Format Guidelines
 * `fill=currentColor` is set
 * `viewBox="0 0 500 500"` is present
 * no inline width, height, or colors
@@ -27,8 +27,8 @@ Format Guidelines
 </svg>
 ```
 
-## Manipulating SVG's
-<p class="text-ignite"><strong>Note:</strong> These examples below reference Flo-SCSS's SVG sprite sheet and may not reflect how your application references SVG. The names of the SVG icons should remain the same.</p>
+## Manipulating SVG
+<p class="text-ignite"><strong>Note:</strong> These examples below uses Flo-SCSS's SVG sprite sheet and may not reflect how your application references SVG. The names of the SVG icons should remain the same.</p>
 
 
 
@@ -50,21 +50,6 @@ Apply `.icon`, `.icon-sm`, and `.icon-lg` to size icons directly.
 {% endcapture %}
 {% include example.html content=example %}
 
-If SVG are added to the site dynamically, icons can inherit width and height from their parent container.
-
-{% capture example %}
-<div class="row row-cols-4 align-items-center">
-  <svg>
-    <use xlink:href="#close_circle" />
-  </svg>
-  <svg>
-    <use xlink:href="#close_circle" />
-  </svg>
-  <svg>
-    <use xlink:href="#close_circle" />
-  </svg>
-</div>
-{% endcapture %}
 
 ### Color
 

--- a/site/docs/components/logos.md
+++ b/site/docs/components/logos.md
@@ -34,57 +34,41 @@ Logos inherit width and height from the parent container, so the parent containe
 {% include example.html content=example %}
 
 
-### Color
-There are four color variations of the FloSports logos.
-
-{% capture example %}
-<div class="row align-items-center">
-  <svg class="text-900 col-4"> <!-- colors svg -->
-    <use xlink:href="#flofc-hawk" />
-  </svg>
-  <p class="caption mt-1">flosports-hawk</p>
-  <svg class="text-900 col-4"> <!-- colors svg -->
-    <use xlink:href="#flofc-hawk" />
-  </svg>
-  <p class="caption mt-1">flosports-hawk</p>
-</div>
-<div class="row align-items-center bg-black">
-  <svg class="text-100 col-4"> <!-- colors svg -->
-    <use xlink:href="#flofc-hawk" />
-  </svg>
-  <p class="caption mt-1">flosports-hawk</p>
-  <svg class="text-100 col-4"> <!-- colors svg -->
-    <use xlink:href="#flofc-hawk" />
-  </svg>
-  <p class="caption mt-1">flosports-hawk</p>
-</div>
-{% endcapture %}
-{% include example.html content=example %}
-
-
-#### Multiple Colors
-Targeted class are available to color the hawk or text independent of each other. In the FloSports logo below `class="flo-svg-logo-graphic"` is targeted to color the hawk red independently of the logo title.
-
-- `class="flo-svg-logo-title"` will change the color of the text
-- `class="flo-svg-logo-graphic"` will change the color of the icon(hawk)
-
 ## FloSports 
-Corporate Logo
+There are four color variations of the corporate logos.
 
-<div class="row mb-3">  
-  <div class="col-md-6 d-flex flex-column bg-black text-100 align-items-center justify-content-center pt-3 mb-3">
-    <svg>
+<div class="row mb-3">
+  <div class="col-md-6 d-flex flex-column align-items-center justify-content-center pt-3 mb-3">
+    <svg class="text-900 icon">
       <use xlink:href="#flosports-hawk" />
     </svg>
     <p class="caption mt-1">flosports-hawk</p>
   </div>
-  <div class="col-md-6 d-flex flex-column align-items-center justify-content-center">
+  <div class="col-md-6 d-flex flex-column bg-black text-100 align-items-center justify-content-center pt-3 mb-3">
+    <svg class="text-100 icon">
+      <use xlink:href="#flosports-hawk" />
+    </svg>
+    <p class="caption mt-1">flosports-hawk</p>
+  </div>
+  <div class="alternate-logo col-md-6 d-flex flex-column bg-black text-100 align-items-center justify-content-center pt-3 mb-3">
+    <svg class="text-100 icon">
+      <use xlink:href="#flosports-hawk" />
+    </svg>
+    <p class="caption mt-1">flosports-hawk</p>
+  </div>
+  <div class="col-md-6 d-flex flex-column align-items-center justify-content-center pt-3 mb-3">
     <svg class="icon text-900">
       <use xlink:href="#flosports-hawk" />
     </svg>
     <p class="caption mt-1">flosports-hawk</p>
   </div>
 </div>
+
+#### Multiple Colors
+Targeted class are available to color the hawk or text independent of each other. In the FloSports logo below `class="flo-svg-logo-graphic"` is targeted to color the hawk red independently of the logo title.
+
+- `class="flo-svg-logo-title"` will change the color of the text
+- `class="flo-svg-logo-graphic"` will change the color of the icon(hawk)
 
 ## Brands
 FloSports network of brands (verticals).

--- a/site/docs/components/logos.md
+++ b/site/docs/components/logos.md
@@ -39,28 +39,28 @@ There are four color variations of the corporate logos.
 
 <div class="row mb-3">
   <div class="col-md-6 d-flex flex-column align-items-center justify-content-center pt-3 mb-3">
-    <svg class="text-900 icon">
-      <use xlink:href="#flosports-hawk" />
+    <svg class="solid-logo text-900 icon">
+      <use xlink:href="#flosoftball-hawk" />
     </svg>
-    <p class="caption mt-1">flosports-hawk</p>
+    <p class="caption mt-1">dark</p>
+  </div>
+  <div class="col-md-6 d-flex flex-column bg-black text-100 align-items-center justify-content-center pt-3 mb-3">
+    <svg class="solid-logo text-100 icon">
+      <use xlink:href="#flosoftball-hawk" />
+    </svg>
+    <p class="caption mt-1">white</p>
   </div>
   <div class="col-md-6 d-flex flex-column bg-black text-100 align-items-center justify-content-center pt-3 mb-3">
     <svg class="text-100 icon">
       <use xlink:href="#flosports-hawk" />
     </svg>
-    <p class="caption mt-1">flosports-hawk</p>
-  </div>
-  <div class="alternate-logo col-md-6 d-flex flex-column bg-black text-100 align-items-center justify-content-center pt-3 mb-3">
-    <svg class="text-100 icon">
-      <use xlink:href="#flosports-hawk" />
-    </svg>
-    <p class="caption mt-1">flosports-hawk</p>
+    <p class="caption mt-1">alternate white</p>
   </div>
   <div class="col-md-6 d-flex flex-column align-items-center justify-content-center pt-3 mb-3">
     <svg class="icon text-900">
       <use xlink:href="#flosports-hawk" />
     </svg>
-    <p class="caption mt-1">flosports-hawk</p>
+    <p class="caption mt-1">alternate dark</p>
   </div>
 </div>
 

--- a/site/docs/components/logos.md
+++ b/site/docs/components/logos.md
@@ -6,20 +6,11 @@ group: components
 toc: true
 ---
 
-## Add Logo
-Logos are stored on AWS library, and accessed with the API.
-
 ## Modifiers
 ### Sizing
-Logos inherit width and height from the parent container, so the parent container can set the SVG's dimensions.
+Logos inherit width and height from the parent container, so the parent container can set the SVG dimensions.
 
 {% capture example %}
-<div class="row row-cols-2 align-items-center color-800"> <!-- reference size in parent -->
-  <svg>
-    <use xlink:href="#flofc-hawk" />
-  </svg>
- </div> 
-
 <div class="row row-cols-6 align-items-center">  <!-- reference size in parent -->
   <svg>
     <use xlink:href="#flofc-hawk" />
@@ -32,27 +23,40 @@ Logos inherit width and height from the parent container, so the parent containe
   </svg>
 </div>
 
+<div class="row row-cols-2 align-items-center text-800"> <!-- reference size in parent -->
+  <svg>
+    <use xlink:href="#flofc-hawk" />
+  </svg>
+</div> 
+
+
 {% endcapture %}
 {% include example.html content=example %}
 
 
 ### Color
-Logos can have one color or variant colors. Descriptive classes can change the icon(hawk) or the brand name colors. Setting `fill=currentColor` in the SVG allows the SVG's colors to be controlled by CSS and added classes. 
-
-#### One Color 
-Below you can see the SVG's color changing by adding `.color-class` to the svg or parent tag.
+There are four color variations of the FloSports logos.
 
 {% capture example %}
-<div class="row row-cols-4 align-items-center">
-  <svg class="color-800"> <!-- colors svg -->
+<div class="row align-items-center">
+  <svg class="text-900 col-4"> <!-- colors svg -->
     <use xlink:href="#flofc-hawk" />
   </svg>
-  <svg class="color-500"> <!-- colors svg -->
+  <p class="caption mt-1">flosports-hawk</p>
+  <svg class="text-900 col-4"> <!-- colors svg -->
     <use xlink:href="#flofc-hawk" />
   </svg>
-  <svg class="color-ignite"> <!-- colors svg -->
+  <p class="caption mt-1">flosports-hawk</p>
+</div>
+<div class="row align-items-center bg-black">
+  <svg class="text-100 col-4"> <!-- colors svg -->
     <use xlink:href="#flofc-hawk" />
   </svg>
+  <p class="caption mt-1">flosports-hawk</p>
+  <svg class="text-100 col-4"> <!-- colors svg -->
+    <use xlink:href="#flofc-hawk" />
+  </svg>
+  <p class="caption mt-1">flosports-hawk</p>
 </div>
 {% endcapture %}
 {% include example.html content=example %}
@@ -68,14 +72,14 @@ Targeted class are available to color the hawk or text independent of each other
 Corporate Logo
 
 <div class="row mb-3">  
-  <div class="col-md-6 d-flex flex-column bg-black color-100 align-items-center justify-content-center pt-3 mb-3">
-    <svg class="icon">
+  <div class="col-md-6 d-flex flex-column bg-black text-100 align-items-center justify-content-center pt-3 mb-3">
+    <svg>
       <use xlink:href="#flosports-hawk" />
     </svg>
     <p class="caption mt-1">flosports-hawk</p>
   </div>
   <div class="col-md-6 d-flex flex-column align-items-center justify-content-center">
-    <svg class="icon color-900">
+    <svg class="icon text-900">
       <use xlink:href="#flosports-hawk" />
     </svg>
     <p class="caption mt-1">flosports-hawk</p>
@@ -85,7 +89,7 @@ Corporate Logo
 ## Brands
 FloSports network of brands (verticals).
 
-<div class="row mb-3 color-500">
+<div class="row mb-3 text-500">
 <!-- baseball bj -->
   <div class="col-md-6  d-flex flex-column align-items-center justify-content-center">
     <svg class="icon-sm">
@@ -253,7 +257,7 @@ FloSports network of brands (verticals).
 #### Live player
 A one color white logo is used on the Live player.
 
-<div class="row color-100">
+<div class="row text-100">
    <div class="col-md-6 d-flex flex-column align-items-center justify-content-center bg-black px-5">
     <svg>
       <use xlink:href="#flo_hawk" />
@@ -268,13 +272,13 @@ Other brands part of FloSports network
 
 
 ### Varsity
-Varsity has one color and multiple color svg options. 
+Varsity has one color and multiple color SVG options. 
 
-**One color SVGs**
+**One color SVG**
 * `varsity_stacked.svg`
 * `varsity_white_logo.svg`
 
-**Multiple Color SVGs**
+**Multiple Color SVG**
 These have additional class to control color independently.
 - `varsity_stacked_color.svg`
    - change the V color with `class="varsity_stacked_v"`
@@ -289,7 +293,7 @@ These have additional class to control color independently.
    - change the pill with `class="varsity_logo_pill"`
 
 
-<div class="row bg-black color-100 mb-3">
+<div class="row bg-black text-100 mb-3">
   <div class="col-md-6 col-lg-3 d-flex flex-column align-items-center justify-content-center">
     <svg>
       <use xlink:href="#varsity_stacked" />
@@ -325,7 +329,7 @@ These have additional class to control color independently.
 #### Live player
 A one color white logo is used on the Live player.
 
-<div class="row color-100">
+<div class="row text-100">
    <div class="col-md-6 col-lg-4 d-flex flex-column align-items-center justify-content-center bg-black px-5">
     <svg>
       <use xlink:href="#varsity_white_logo" />
@@ -336,7 +340,6 @@ A one color white logo is used on the Live player.
 
 
 ### MileSplit
-Co-brand logo used on Stripe and funnel.
 <div class="row">
    <div class="col-md-6 col-lg-4 d-flex flex-column align-items-center justify-content-center">
     <svg>


### PR DESCRIPTION
Remove references to how web app uses SVG. That can go into storybook or webapp docs

https://flo-scss-logo-documenta-jye9ge.herokuapp.com/docs/components/icons/

https://flo-scss-logo-documenta-jye9ge.herokuapp.com/docs/components/logos/