### PR TITLE
feat: Removed the text capitalize style from the btn classes.

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -11,7 +11,6 @@
   line-height: $btn-line-height;
   color: $body-color;
   text-align: center;
-  text-transform: $btn-text-transform;
   letter-spacing: $btn-letter-spacing;
   white-space: $btn-white-space;
   vertical-align: middle;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -696,7 +696,6 @@ $btn-padding-x: from-pixels(24) !default;
 $btn-font-family: $input-btn-font-family !default;
 $btn-line-height: 20 / 14 !default;
 $btn-letter-spacing: $input-btn-letter-spacing !default;
-$btn-text-transform: $input-btn-text-transform !default;
 $btn-white-space: null !default; // Set to `nowrap` to prevent text wrapping
 
 $btn-padding-y-sm: from-pixels(6) !default;


### PR DESCRIPTION
All of our btn classes also had a style set that would capitalize text. This PR removes that at the direction of the design team.

![Screen Shot 2020-05-21 at 9 54 30 AM](https://user-images.githubusercontent.com/12106376/82566136-78cf7080-9b49-11ea-9f07-bfdd744d9427.png)
