### PR TITLE
fix: remove hover effect on active buttons in button group

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -71,6 +71,11 @@ $btn-group-focus: 0 0 0 $btn-focus-width rgba(255, 20, 15, 0.2) !important;
     &.active {
     @include btn-outline-secondary-active;
 
+      &:hover,
+      &.hover {
+        @include btn-outline-secondary-active;
+      }
+
       &:focus,
       &.focus,
       &:focus:not([disabled]){


### PR DESCRIPTION
Goal: Only apply the gray hover in button groups if the button is NOT active.

This was frustrating because, for whatever reason, doing something like `&:hover:not(.active)` or `&:hover:not(:active)`  or any combo of that, had no effect. So I ended up having to just redeclare the hover rules inside the `&:active` block.

[FLO-12070](https://flocasts.atlassian.net/browse/FLO-12070)